### PR TITLE
bump base images to tag 2023.07.05

### DIFF
--- a/docker-images/base/pangeo-notebook-shared/Dockerfile
+++ b/docker-images/base/pangeo-notebook-shared/Dockerfile
@@ -1,4 +1,4 @@
-FROM pangeo/pangeo-notebook:2023.04.15
+FROM pangeo/pangeo-notebook:2023.07.05
 
 # NOTE: reasoning to use ONBUILD below from JH: https://github.com/pangeo-data/pangeo-docker-images/blob/master/base-image/Dockerfile#L83-L96
 # if override arg passed then use that instead of default in base image

--- a/docker-images/base/pangeo-notebook/Dockerfile
+++ b/docker-images/base/pangeo-notebook/Dockerfile
@@ -1,4 +1,4 @@
-FROM pangeo/pangeo-notebook:2023.04.15
+FROM pangeo/pangeo-notebook:2023.07.05
 
 # reasoning to use ONBUILD below from JH: https://github.com/pangeo-data/pangeo-docker-images/blob/master/base-image/Dockerfile#L83-L96
 # if override arg passed then use that instead of default in base image

--- a/docker-images/base/pytorch-notebook/Dockerfile
+++ b/docker-images/base/pytorch-notebook/Dockerfile
@@ -1,4 +1,4 @@
-FROM pangeo/pytorch-notebook:2023.04.15
+FROM pangeo/pytorch-notebook:2023.07.05
 
 # reasoning to use ONBUILD below from JH: https://github.com/pangeo-data/pangeo-docker-images/blob/master/base-image/Dockerfile#L83-L96
 # if override arg passed then use that instead of default in base image


### PR DESCRIPTION
To be able to provide https://nasa-veda.2i2c.cloud with a singleuser image we need to make sure all base images to `tag:2023.07.05` so it matches what we currently have: https://github.com/2i2c-org/infrastructure/pull/2763/files