### PR TITLE
update custom pangeo-notebook to base sha

### DIFF
--- a/docker-images/custom/nasa-veda-singleuser/Dockerfile
+++ b/docker-images/custom/nasa-veda-singleuser/Dockerfile
@@ -1,6 +1,6 @@
-FROM public.ecr.aws/nasa-veda/pangeo-notebook:56cc88560df6cf444d49af7d8f0f7a340d412ce0f10ab441254cb712b9480281
+FROM public.ecr.aws/nasa-veda/pangeo-notebook:60b023fba2ca5f9e19d285c245987e368e27c0ea626b65777b204cec14b697c7
 # above hash is JH version 4.x
-ENV VERSION=0.0.1
+ENV VERSION=0.0.2
 # NOTE: the below script is used as a k8s post-start hook to copy /veda-docs repository to all user pods
 COPY --chown=jovyan:jovyan ./k8s-lifecycle-hook-post-start.py /opt/k8s-lifecycle-hook-post-start.py
 RUN chmod +x /opt/k8s-lifecycle-hook-post-start.py


### PR DESCRIPTION
#### Overview

As talked about in [step 2 in this ticket](https://github.com/NASA-IMPACT/veda-jh-environments/issues/41) this PR adds the newest hash from [ECR base pangeo-notebook](https://us-east-1.console.aws.amazon.com/ecr/repositories/public/853558080719/pangeo-notebook?region=us-east-1) to the custom image