### PR TITLE
bump version of pangeo-notebook

### DIFF
--- a/docker-images/base/pangeo-notebook/Dockerfile
+++ b/docker-images/base/pangeo-notebook/Dockerfile
@@ -1,4 +1,4 @@
-FROM pangeo/pangeo-notebook:2024.03.13
+FROM pangeo/pangeo-notebook:2024.04.05
 
 # reasoning to use ONBUILD below from JH: https://github.com/pangeo-data/pangeo-docker-images/blob/master/base-image/Dockerfile#L83-L96
 # if override arg passed then use that instead of default in base image


### PR DESCRIPTION
bumping version of pangeo-notebook, mostly to pull in the upstream fix in `jupyterlab-myst` for https://github.com/NASA-IMPACT/veda-jupyterhub/issues/14

cc @ranchodeluxe @abarciauskas-bgse 